### PR TITLE
Fix two bugs that may cause program crashed, when the World or WorldUI object is deleted.

### DIFF
--- a/libstage/model.cc
+++ b/libstage/model.cc
@@ -311,7 +311,7 @@ Model::~Model(void)
     // erase from the static map of all models
     modelsbyid.erase(id);
 
-    world->RemoveModel(this);
+//    world->RemoveModel(this);
   }
 }
 

--- a/libstage/stage.hh
+++ b/libstage/stage.hh
@@ -1472,6 +1472,7 @@ updates. */
   static void fasttimeCb(Fl_Widget *w, WorldGui *wg);
   static void resetViewCb(Fl_Widget *w, WorldGui *wg);
   static void moreHelptCb(Fl_Widget *w, WorldGui *wg);
+  static void UpdateCallback(WorldGui *world);
 
   // GUI functions
   bool saveAsDialog();

--- a/libstage/worldgui.cc
+++ b/libstage/worldgui.cc
@@ -253,6 +253,10 @@ WorldGui::~WorldGui()
     delete oDlg;
   if (canvas)
     delete canvas;
+
+  // remove the old callback, wherever it was
+  Fl::remove_idle((Fl_Timeout_Handler)UpdateCallback, this);
+  Fl::remove_timeout((Fl_Timeout_Handler)UpdateCallback, this);
 }
 
 void WorldGui::Show()
@@ -399,7 +403,7 @@ bool WorldGui::Save(const char *filename)
   return World::Save(filename);
 }
 
-static void UpdateCallback(WorldGui *world)
+void WorldGui::UpdateCallback(WorldGui *world)
 {
   world->Update();
 }


### PR DESCRIPTION
 Two bugs: 1. When deleting the world and its internal models (kept by pointer), the world is deleted before the model object, and then the model invokes the world's RemoveModel function to remove itself from World's model list. 2. In worldGUI, it registers some callback function to FLTK to trigger updating, but problems may happen when the worldGUI is deleted, the FLTK still keep a reference to the callback function and try to invoke it, which cause a crash. Note: For the 1 bug, current solution may not be the very right way to solve it, but it can be solved in our situation, and it will not cause a memory leak.